### PR TITLE
Remove json schema ref resolution, as it can be infinite recursion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   { name = "Razvan-Ion Radulescu" },
   { name = "Andrei-Stefan Ghiurtu" },

--- a/src/utcp/client/openapi_converter.py
+++ b/src/utcp/client/openapi_converter.py
@@ -139,6 +139,7 @@ class OpenApiConverter:
 
     def _resolve_schema(self, schema: Dict[str, Any]) -> Dict[str, Any]:
         """Recursively resolves all $refs in a schema object."""
+        return schema
         if isinstance(schema, dict):
             if "$ref" in schema:
                 resolved_ref = self._resolve_ref(schema["$ref"])

--- a/src/utcp/version.py
+++ b/src/utcp/version.py
@@ -2,7 +2,7 @@ from importlib.metadata import version, PackageNotFoundError
 import tomli
 from pathlib import Path
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 try:
     __version__ = version("utcp")
 except PackageNotFoundError:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed recursive JSON schema $ref resolution to prevent infinite loops during schema parsing. Updated package version to 0.2.2.

<!-- End of auto-generated description by cubic. -->

