### PR TITLE
Add docs and update http to 1.0.2

### DIFF
--- a/plugins/communication_protocols/http/pyproject.toml
+++ b/plugins/communication_protocols/http/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp-http"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   { name = "UTCP Contributors" },
 ]

--- a/plugins/communication_protocols/http/src/utcp_http/http_communication_protocol.py
+++ b/plugins/communication_protocols/http/src/utcp_http/http_communication_protocol.py
@@ -311,7 +311,7 @@ class HttpCommunicationProtocol(CommunicationProtocol):
                 ) as response:
                     response.raise_for_status()
                     
-                    content_type = response.headers.get('Content-Type', '')
+                    content_type = response.headers.get('Content-Type', '').lower()
                     if 'application/json' in content_type:
                         return await response.json()
                     return await response.text()

--- a/plugins/communication_protocols/http/src/utcp_http/http_communication_protocol.py
+++ b/plugins/communication_protocols/http/src/utcp_http/http_communication_protocol.py
@@ -310,7 +310,11 @@ class HttpCommunicationProtocol(CommunicationProtocol):
                     timeout=aiohttp.ClientTimeout(total=30.0)
                 ) as response:
                     response.raise_for_status()
-                    return await response.json()
+                    
+                    content_type = response.headers.get('Content-Type', '')
+                    if 'application/json' in content_type:
+                        return await response.json()
+                    return await response.text()
                     
             except aiohttp.ClientResponseError as e:
                 logger.error(f"Error calling tool '{tool_name}' on call template '{tool_call_template.name}': {e}")


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix HTTP response parsing to respect Content-Type and bump utcp-http to 1.0.2. Also simplify SSE by removing active connection tracking and related teardown.

- **Bug Fixes**
  - HTTP: Only parse JSON when Content-Type includes application/json; otherwise return response text to avoid JSON decode errors.

- **Refactors**
  - SSE: Removed _active_connections and close(); deregister_manual is now a no-op.
  - SSE: No longer stores response/session in call_tool_streaming; the stream consumer manages lifecycle.
  - Tests: Removed close() teardown and deregister cleanup test.

<!-- End of auto-generated description by cubic. -->

