### PR TITLE
core[dev] install fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ git clone https://github.com/universal-tool-calling-protocol/python-utcp.git
 cd python-utcp
 
 # Install the core package in editable mode with dev dependencies
-pip install -e core[dev]
+pip install -e "core[dev]"
 
 # Install a specific protocol plugin in editable mode
 pip install -e plugins/communication_protocols/http


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the core editable install command in the README by quoting extras: pip install -e "core[dev]". Prevents shell globbing/bracket expansion (e.g., in zsh) that caused install failures.

<!-- End of auto-generated description by cubic. -->

