### PR TITLE
feat: Add x-utcp-auth OpenAPI extension with auth inheritance for tools

### DIFF
--- a/plugins/communication_protocols/http/src/utcp_http/http_communication_protocol.py
+++ b/plugins/communication_protocols/http/src/utcp_http/http_communication_protocol.py
@@ -197,7 +197,7 @@ class HttpCommunicationProtocol(CommunicationProtocol):
                             utcp_manual = UtcpManualSerializer().validate_dict(response_data)
                         else:
                             logger.info(f"Assuming OpenAPI spec from '{manual_call_template.name}'. Converting to UTCP manual.")
-                            converter = OpenApiConverter(response_data, spec_url=manual_call_template.url, call_template_name=manual_call_template.name)
+                            converter = OpenApiConverter(response_data, spec_url=manual_call_template.url, call_template_name=manual_call_template.name, inherited_auth=manual_call_template.auth)
                             utcp_manual = converter.convert()
                         
                         return RegisterManualResult(

--- a/plugins/communication_protocols/http/tests/test_x_utcp_auth_extension.py
+++ b/plugins/communication_protocols/http/tests/test_x_utcp_auth_extension.py
@@ -1,0 +1,361 @@
+"""Tests for x-utcp-auth OpenAPI extension support.
+
+This module tests the custom x-utcp-auth extension that allows OpenAPI specifications
+to include UTCP-specific authentication configuration directly in operations.
+"""
+
+import pytest
+from utcp_http.openapi_converter import OpenApiConverter
+from utcp_http.http_call_template import HttpCallTemplate
+from utcp.data.auth_implementations.api_key_auth import ApiKeyAuth
+from utcp.data.auth_implementations.basic_auth import BasicAuth
+from utcp.data.auth_implementations.oauth2_auth import OAuth2Auth
+
+
+def test_x_utcp_auth_api_key_extension():
+    """Test that x-utcp-auth extension with API key auth is processed correctly."""
+    openapi_spec = {
+        "openapi": "3.0.1",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": {
+            "/protected": {
+                "get": {
+                    "operationId": "get_protected_data",
+                    "summary": "Get Protected Data",
+                    "x-utcp-auth": {
+                        "auth_type": "api_key",
+                        "var_name": "Authorization",
+                        "location": "header"
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    converter = OpenApiConverter(openapi_spec)
+    manual = converter.convert()
+    
+    assert len(manual.tools) == 1
+    tool = manual.tools[0]
+    
+    # Check that auth was extracted from x-utcp-auth extension
+    assert tool.tool_call_template.auth is not None
+    assert isinstance(tool.tool_call_template.auth, ApiKeyAuth)
+    assert tool.tool_call_template.auth.var_name == "Authorization"
+    assert tool.tool_call_template.auth.location == "header"
+    assert tool.tool_call_template.auth.api_key.startswith("${API_KEY_")
+
+
+def test_x_utcp_auth_takes_precedence_over_standard_security():
+    """Test that x-utcp-auth extension takes precedence over standard OpenAPI security."""
+    openapi_spec = {
+        "openapi": "3.0.1",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "servers": [{"url": "https://api.example.com"}],
+        "components": {
+            "securitySchemes": {
+                "bearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer"
+                }
+            }
+        },
+        "paths": {
+            "/protected": {
+                "get": {
+                    "operationId": "get_protected_data",
+                    "summary": "Get Protected Data",
+                    "security": [{"bearerAuth": []}],
+                    "x-utcp-auth": {
+                        "auth_type": "api_key",
+                        "var_name": "X-API-Key",
+                        "location": "header"
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    converter = OpenApiConverter(openapi_spec)
+    manual = converter.convert()
+    
+    assert len(manual.tools) == 1
+    tool = manual.tools[0]
+    
+    # Should use x-utcp-auth, not the standard security scheme
+    assert tool.tool_call_template.auth is not None
+    assert isinstance(tool.tool_call_template.auth, ApiKeyAuth)
+    assert tool.tool_call_template.auth.var_name == "X-API-Key"
+    assert tool.tool_call_template.auth.location == "header"
+
+
+def test_fallback_to_standard_security_when_no_x_utcp_auth():
+    """Test that standard OpenAPI security is used when x-utcp-auth is not present."""
+    openapi_spec = {
+        "openapi": "3.0.1",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "servers": [{"url": "https://api.example.com"}],
+        "components": {
+            "securitySchemes": {
+                "bearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer"
+                }
+            }
+        },
+        "paths": {
+            "/protected": {
+                "get": {
+                    "operationId": "get_protected_data",
+                    "summary": "Get Protected Data",
+                    "security": [{"bearerAuth": []}],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    converter = OpenApiConverter(openapi_spec)
+    manual = converter.convert()
+    
+    assert len(manual.tools) == 1
+    tool = manual.tools[0]
+    
+    # Should use standard security scheme
+    assert tool.tool_call_template.auth is not None
+    assert isinstance(tool.tool_call_template.auth, ApiKeyAuth)
+    assert tool.tool_call_template.auth.var_name == "Authorization"
+    assert tool.tool_call_template.auth.location == "header"
+    assert tool.tool_call_template.auth.api_key.startswith("Bearer ${API_KEY_")
+
+
+def test_mixed_operations_with_and_without_x_utcp_auth():
+    """Test OpenAPI spec with mixed operations - some with x-utcp-auth, some without."""
+    openapi_spec = {
+        "openapi": "3.0.1",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": {
+            "/public": {
+                "get": {
+                    "operationId": "get_public_data",
+                    "summary": "Get Public Data",
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/protected": {
+                "get": {
+                    "operationId": "get_protected_data",
+                    "summary": "Get Protected Data",
+                    "x-utcp-auth": {
+                        "auth_type": "api_key",
+                        "var_name": "Authorization",
+                        "location": "header"
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    converter = OpenApiConverter(openapi_spec)
+    manual = converter.convert()
+    
+    assert len(manual.tools) == 2
+    
+    # Find tools by name
+    public_tool = next(t for t in manual.tools if t.name == "get_public_data")
+    protected_tool = next(t for t in manual.tools if t.name == "get_protected_data")
+    
+    # Public tool should have no auth
+    assert public_tool.tool_call_template.auth is None
+    
+    # Protected tool should have auth from x-utcp-auth
+    assert protected_tool.tool_call_template.auth is not None
+    assert isinstance(protected_tool.tool_call_template.auth, ApiKeyAuth)
+    assert protected_tool.tool_call_template.auth.var_name == "Authorization"
+    assert protected_tool.tool_call_template.auth.location == "header"
+
+
+def test_auth_inheritance_from_manual_call_template():
+    """Test that tools inherit authentication from manual call template."""
+    openapi_spec = {
+        "openapi": "3.0.1",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": {
+            "/data": {
+                "get": {
+                    "operationId": "get_data",
+                    "summary": "Get Data",
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    # Manual call template with auth
+    manual_auth = ApiKeyAuth(
+        api_key="Bearer token-123",
+        var_name="Authorization",
+        location="header"
+    )
+    
+    converter = OpenApiConverter(openapi_spec, inherited_auth=manual_auth)
+    manual = converter.convert()
+    
+    assert len(manual.tools) == 1
+    tool = manual.tools[0]
+    
+    # Tool should inherit auth from manual call template
+    assert tool.tool_call_template.auth is not None
+    assert isinstance(tool.tool_call_template.auth, ApiKeyAuth)
+    assert tool.tool_call_template.auth.api_key == "Bearer token-123"
+    assert tool.tool_call_template.auth.var_name == "Authorization"
+    assert tool.tool_call_template.auth.location == "header"
+
+
+def test_x_utcp_auth_overrides_inherited_auth():
+    """Test that x-utcp-auth extension overrides inherited auth from manual call template."""
+    openapi_spec = {
+        "openapi": "3.0.1",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": {
+            "/data": {
+                "get": {
+                    "operationId": "get_data",
+                    "summary": "Get Data",
+                    "x-utcp-auth": {
+                        "auth_type": "api_key",
+                        "var_name": "X-Custom-Key",
+                        "location": "header"
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    # Manual call template with different auth
+    manual_auth = ApiKeyAuth(
+        api_key="Bearer token-123",
+        var_name="Authorization", 
+        location="header"
+    )
+    
+    converter = OpenApiConverter(openapi_spec, inherited_auth=manual_auth)
+    manual = converter.convert()
+    
+    assert len(manual.tools) == 1
+    tool = manual.tools[0]
+    
+    # Tool should use x-utcp-auth, not inherited auth
+    assert tool.tool_call_template.auth is not None
+    assert isinstance(tool.tool_call_template.auth, ApiKeyAuth)
+    assert tool.tool_call_template.auth.var_name == "X-Custom-Key"
+    assert tool.tool_call_template.auth.location == "header"
+    # Should generate placeholder, not use inherited value
+    assert tool.tool_call_template.auth.api_key.startswith("${API_KEY_")
+
+
+def test_no_auth_inheritance_when_manual_has_no_auth():
+    """Test that no auth is applied when manual call template has no auth."""
+    openapi_spec = {
+        "openapi": "3.0.1",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "servers": [{"url": "https://api.example.com"}],
+        "paths": {
+            "/data": {
+                "get": {
+                    "operationId": "get_data",
+                    "summary": "Get Data",
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    converter = OpenApiConverter(openapi_spec, inherited_auth=None)
+    manual = converter.convert()
+    
+    assert len(manual.tools) == 1
+    tool = manual.tools[0]
+    
+    # Tool should have no auth
+    assert tool.tool_call_template.auth is None


### PR DESCRIPTION
## Summary
Adds support for the `x-utcp-auth` OpenAPI extension that enables seamless authentication inheritance from manual call templates, providing fine-grained per-operation auth control while maintaining backward compatibility.

## Problem Solved
- OpenAPI converter only processed standard security schemes, limiting UTCP-specific auth requirements
- Users needed a way to configure authentication at the manual call template level and have it automatically inherited by generated tools
- Required per-operation auth override capability without breaking existing specs

## Key Features
- **x-utcp-auth Extension**: Per-operation authentication override via custom OpenAPI extension
- **Authentication Inheritance**: Tools automatically inherit auth from parent manual call templates when no OpenAPI security is defined
- **Clear Precedence**: `x-utcp-auth` → OpenAPI security → Inherited auth → No auth
- **Smart Reuse**: When `x-utcp-auth` is used, it reuses inherited auth values if compatible, otherwise generates placeholders
- **Case-Insensitive Headers**: Normalized header name comparison for better compatibility
- **Safe Type Handling**: Guards against malformed `x-utcp-auth` values
- **Backward Compatibility**: Existing OpenAPI security schemes continue to work unchanged

### Actual Precedence (in order):
1. `x-utcp-auth` extension (if present) - always takes precedence
2. Standard OpenAPI security (if no `x-utcp-auth` but security schemes exist)  
3. Inherited auth (if no `x-utcp-auth` AND no OpenAPI security)
4. No auth (if none of the above)

## Usage Example
• `x-utcp-auth` is a novel extension field created by this PR specifically for UTCP
• It's an optional OpenAPI extension (following OpenAPI's `x-*` extension pattern) that maintains backward compatibility
• The UTCP converter recognizes and processes this extension during conversion
• It gets consumed and transformed into standard UTCP auth based on the precedence rules

1. Manual Call Template Configuration:
```json
{
  "manual_call_templates": [{
    "name": "github_api", 
    "call_template_type": "http",
    "url": "https://api.github.com/openapi.json",
    "auth": {
      "auth_type": "api_key",
      "api_key": "Bearer ghp_xxxxxxxxxxxx",
      "var_name": "Authorization",
      "location": "header"
    }
  }]
}
```

2. OpenAPI Spec with Novel `x-utcp-auth` Extension (Create as transient step by the UTCP converter, but could be also defined inside an UTCP-friendly OpenAPI spec):
This PR introduces support for the new `x-utcp-auth` extension field that API providers can optionally add to their OpenAPI specifications for UTCP-specific authentication control:
```json
{
  "paths": {
    "/user/repos": {
      "get": {
        "operationId": "list_user_repos",
        "x-utcp-auth": {
          "auth_type": "api_key",
          "var_name": "Authorization", 
          "location": "header"
        }
      }
    }
  }
}
```
Note: This extension is backward-compatible with OpenAPI standards, so it could be included in an OpenAPI spec and would be ignored by non-UTCP tools.

3. Generated UTCP Tool (Final Result):
The UTCP converter processes the `x-utcp-auth` extension and applies the precedence rules to generate tools with concrete authentication:
```json
{
  "name": "list_user_repos",
  "tool_call_template": {
    "auth": {
      "auth_type": "api_key", 
      "api_key": "Bearer ghp_xxxxxxxxxxxx",  // ← Inherited from manual call template
      "var_name": "Authorization",
      "location": "header"
    }
  }
}
```

All generated tools automatically inherit the GitHub token authentication without requiring environment variables or additional configuration.

## Testing
- ✅ 7 new comprehensive test cases covering all inheritance scenarios
- ✅ All existing tests pass (97/97)
- ✅ Backward compatibility verified

## Files Changed
- `openapi_converter.py`: Core implementation of auth inheritance and `x-utcp-auth` extension
- `http_communication_protocol.py`: Pass manual call template auth to converter
- `test_x_utcp_auth_extension.py`: Comprehensive test coverage