### PR TITLE
Fix bug in mcp plugin

### DIFF
--- a/plugins/communication_protocols/mcp/pyproject.toml
+++ b/plugins/communication_protocols/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp-mcp"
-version = "1.1.1"
+version = "1.1.2"
 authors = [
   { name = "UTCP Contributors" },
 ]

--- a/plugins/communication_protocols/mcp/pyproject.toml
+++ b/plugins/communication_protocols/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp-mcp"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
   { name = "UTCP Contributors" },
 ]

--- a/plugins/communication_protocols/mcp/src/utcp_mcp/mcp_communication_protocol.py
+++ b/plugins/communication_protocols/mcp/src/utcp_mcp/mcp_communication_protocol.py
@@ -387,6 +387,9 @@ class McpCommunicationProtocol(CommunicationProtocol):
         # Check for structured output first - this is the expected behavior
         if hasattr(result, 'structuredContent'):
             self._log_info(f"Found structuredContent: {result.structuredContent}")
+            # If structuredContent has a 'result' key, unwrap it
+            if isinstance(result.structuredContent, dict) and 'result' in result.structuredContent:
+                return result.structuredContent['result']
             return result.structuredContent
         
         # Process content if available (fallback)

--- a/plugins/communication_protocols/mcp/src/utcp_mcp/mcp_communication_protocol.py
+++ b/plugins/communication_protocols/mcp/src/utcp_mcp/mcp_communication_protocol.py
@@ -384,12 +384,12 @@ class McpCommunicationProtocol(CommunicationProtocol):
     def _process_tool_result(self, result, tool_name: str) -> Any:
         self._log_info(f"Processing tool result for '{tool_name}', type: {type(result)}")
         
-        # Check for structured output first
+        # Check for structured output first - this is the expected behavior
         if hasattr(result, 'structuredContent'):
             self._log_info(f"Found structuredContent: {result.structuredContent}")
             return result.structuredContent
         
-        # Process content if available
+        # Process content if available (fallback)
         if hasattr(result, 'content'):
             content = result.content
             self._log_info(f"Content type: {type(content)}")
@@ -426,6 +426,10 @@ class McpCommunicationProtocol(CommunicationProtocol):
                 return content.json
             
             return content
+        
+        # Handle dictionary with 'result' key
+        if isinstance(result, dict) and 'result' in result:
+            return result['result']
         
         # Fallback to result attribute
         if hasattr(result, 'result'):

--- a/plugins/communication_protocols/mcp/src/utcp_mcp/mcp_communication_protocol.py
+++ b/plugins/communication_protocols/mcp/src/utcp_mcp/mcp_communication_protocol.py
@@ -194,8 +194,8 @@ class McpCommunicationProtocol(CommunicationProtocol):
                         utcp_tool = Tool(
                             name=mcp_tool.name,
                             description=mcp_tool.description,
-                            input_schema=mcp_tool.inputSchema,
-                            output_schema=mcp_tool.outputSchema,
+                            inputs=mcp_tool.inputSchema,
+                            outputs=mcp_tool.outputSchema,
                             tool_call_template=manual_call_template
                         )
                         all_tools.append(utcp_tool)
@@ -212,12 +212,12 @@ class McpCommunicationProtocol(CommunicationProtocol):
                                 resource_tool = Tool(
                                     name=f"{server_name}.resource_{mcp_resource.name}",
                                     description=f"Read resource: {mcp_resource.description or mcp_resource.name}. URI: {mcp_resource.uri}",
-                                    input_schema={
+                                    inputs={
                                         "type": "object",
                                         "properties": {},
                                         "required": []
                                     },
-                                    output_schema={
+                                    outputs={
                                         "type": "object",
                                         "properties": {
                                             "contents": {
@@ -385,9 +385,9 @@ class McpCommunicationProtocol(CommunicationProtocol):
         self._log_info(f"Processing tool result for '{tool_name}', type: {type(result)}")
         
         # Check for structured output first
-        if hasattr(result, 'structured_output'):
-            self._log_info(f"Found structured_output: {result.structured_output}")
-            return result.structured_output
+        if hasattr(result, 'structuredContent'):
+            self._log_info(f"Found structuredContent: {result.structuredContent}")
+            return result.structuredContent
         
         # Process content if available
         if hasattr(result, 'content'):

--- a/plugins/communication_protocols/mcp/tests/test_mcp_http_transport.py
+++ b/plugins/communication_protocols/mcp/tests/test_mcp_http_transport.py
@@ -136,7 +136,7 @@ async def test_http_unstructured_output(
     
     # Call the greet tool and verify the result
     result = await transport.call_tool(None, f"{HTTP_SERVER_NAME}.greet", {"name": "Alice"}, http_mcp_provider)
-    assert result == "Hello, Alice!"
+    assert result == {"result": "Hello, Alice!"}
 
 
 @pytest.mark.asyncio
@@ -152,11 +152,9 @@ async def test_http_list_output(
     # Call the list_items tool and verify the result
     result = await transport.call_tool(None, f"{HTTP_SERVER_NAME}.list_items", {"count": 3}, http_mcp_provider)
     
-    assert isinstance(result, list)
-    assert len(result) == 3
-    assert result[0] == "item_0"
-    assert result[1] == "item_1"
-    assert result[2] == "item_2"
+    assert isinstance(result, dict)
+    assert "result" in result
+    assert result == {"result": ["item_0", "item_1", "item_2"]}
 
 
 @pytest.mark.asyncio
@@ -172,7 +170,7 @@ async def test_http_numeric_output(
     # Call the add_numbers tool and verify the result
     result = await transport.call_tool(None, f"{HTTP_SERVER_NAME}.add_numbers", {"a": 5, "b": 7}, http_mcp_provider)
     
-    assert result == 12
+    assert result == {"result": 12}
 
 
 @pytest.mark.asyncio

--- a/plugins/communication_protocols/mcp/tests/test_mcp_http_transport.py
+++ b/plugins/communication_protocols/mcp/tests/test_mcp_http_transport.py
@@ -136,7 +136,7 @@ async def test_http_unstructured_output(
     
     # Call the greet tool and verify the result
     result = await transport.call_tool(None, f"{HTTP_SERVER_NAME}.greet", {"name": "Alice"}, http_mcp_provider)
-    assert result == {"result": "Hello, Alice!"}
+    assert result == "Hello, Alice!"
 
 
 @pytest.mark.asyncio
@@ -152,9 +152,9 @@ async def test_http_list_output(
     # Call the list_items tool and verify the result
     result = await transport.call_tool(None, f"{HTTP_SERVER_NAME}.list_items", {"count": 3}, http_mcp_provider)
     
-    assert isinstance(result, dict)
-    assert "result" in result
-    assert result == {"result": ["item_0", "item_1", "item_2"]}
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert result == ["item_0", "item_1", "item_2"]
 
 
 @pytest.mark.asyncio
@@ -170,7 +170,7 @@ async def test_http_numeric_output(
     # Call the add_numbers tool and verify the result
     result = await transport.call_tool(None, f"{HTTP_SERVER_NAME}.add_numbers", {"a": 5, "b": 7}, http_mcp_provider)
     
-    assert result == {"result": 12}
+    assert result == 12
 
 
 @pytest.mark.asyncio

--- a/plugins/communication_protocols/mcp/tests/test_mcp_transport.py
+++ b/plugins/communication_protocols/mcp/tests/test_mcp_transport.py
@@ -98,7 +98,7 @@ async def test_unstructured_string_output(transport: McpCommunicationProtocol, m
     await transport.register_manual(None, mcp_manual)
 
     result = await transport.call_tool(None, f"{SERVER_NAME}.greet", {"name": "Alice"}, mcp_manual)
-    assert result == "Hello, Alice!"
+    assert result == {"result": "Hello, Alice!"}
 
 
 @pytest.mark.asyncio
@@ -108,9 +108,9 @@ async def test_list_output(transport: McpCommunicationProtocol, mcp_manual: McpC
 
     result = await transport.call_tool(None, f"{SERVER_NAME}.list_items", {"count": 3}, mcp_manual)
 
-    assert isinstance(result, list)
-    assert len(result) == 3
-    assert result == ["item_0", "item_1", "item_2"]
+    assert isinstance(result, dict)
+    assert "result" in result
+    assert result == {"result": ["item_0", "item_1", "item_2"]}
 
 
 @pytest.mark.asyncio
@@ -120,7 +120,7 @@ async def test_numeric_output(transport: McpCommunicationProtocol, mcp_manual: M
 
     result = await transport.call_tool(None, f"{SERVER_NAME}.add_numbers", {"a": 5, "b": 7}, mcp_manual)
 
-    assert result == 12
+    assert result == {"result": 12}
 
 
 @pytest.mark.asyncio

--- a/plugins/communication_protocols/mcp/tests/test_mcp_transport.py
+++ b/plugins/communication_protocols/mcp/tests/test_mcp_transport.py
@@ -98,7 +98,7 @@ async def test_unstructured_string_output(transport: McpCommunicationProtocol, m
     await transport.register_manual(None, mcp_manual)
 
     result = await transport.call_tool(None, f"{SERVER_NAME}.greet", {"name": "Alice"}, mcp_manual)
-    assert result == {"result": "Hello, Alice!"}
+    assert result == "Hello, Alice!"
 
 
 @pytest.mark.asyncio
@@ -108,9 +108,9 @@ async def test_list_output(transport: McpCommunicationProtocol, mcp_manual: McpC
 
     result = await transport.call_tool(None, f"{SERVER_NAME}.list_items", {"count": 3}, mcp_manual)
 
-    assert isinstance(result, dict)
-    assert "result" in result
-    assert result == {"result": ["item_0", "item_1", "item_2"]}
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert result == ["item_0", "item_1", "item_2"]
 
 
 @pytest.mark.asyncio
@@ -120,7 +120,7 @@ async def test_numeric_output(transport: McpCommunicationProtocol, mcp_manual: M
 
     result = await transport.call_tool(None, f"{SERVER_NAME}.add_numbers", {"a": 5, "b": 7}, mcp_manual)
 
-    assert result == {"result": 12}
+    assert result == 12
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes MCP plugin result handling and aligns Tool field names with MCP conventions, preventing misparsed outputs and making unstructured results consistent. Bumps plugin version to 1.1.2.

- **Bug Fixes**
  - Renamed Tool fields from input_schema/output_schema to inputs/outputs.
  - Read structured output from structuredContent (was structured_output), and unwrap structuredContent["result"] when present.
  - Standardized unstructured outputs to return {"result": ...} for strings, lists, and numbers.
  - Updated tests to match the new output shape.

- **Migration**
  - Replace Tool input_schema/output_schema with inputs/outputs.
  - Update callers to read response["result"] for unstructured outputs; structured outputs come from structuredContent (or its "result" when present).

<sup>Written for commit 5f256432532ac83914d7b9f1ca87f68587e8d162. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



