### PR TITLE
security fixes

### DIFF
--- a/plugins/communication_protocols/gql/pyproject.toml
+++ b/plugins/communication_protocols/gql/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp-gql"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
   { name = "UTCP Contributors" },
 ]

--- a/plugins/communication_protocols/gql/src/utcp_gql/_security.py
+++ b/plugins/communication_protocols/gql/src/utcp_gql/_security.py
@@ -220,7 +220,10 @@ def _same_origin(a: str, b: str) -> bool:
         return False
 
 
-def _scrub_cross_origin_credentials(kwargs: dict) -> None:
+def _scrub_cross_origin_credentials(
+    kwargs: dict,
+    extra_auth_header_names: Optional[frozenset] = None,
+) -> None:
     """Strip auth-bearing kwargs in place when crossing origins.
 
     Mirrors ``utcp_http._security._scrub_cross_origin_credentials`` --
@@ -229,11 +232,14 @@ def _scrub_cross_origin_credentials(kwargs: dict) -> None:
     ``data``) so 307/308 redirects cannot resend an OAuth POST body
     to a new origin.
     """
+    extra = extra_auth_header_names or frozenset()
     headers = kwargs.get("headers")
     if headers is not None:
         scrubbed: Dict[str, Any] = {}
         for k, v in dict(headers).items():
             if _header_is_auth_sensitive(k):
+                continue
+            if isinstance(k, str) and k.lower() in extra:
                 continue
             scrubbed[k] = v
         kwargs["headers"] = scrubbed
@@ -254,6 +260,7 @@ async def safe_request_with_redirects(
     *,
     context: str,
     max_redirects: int = 5,
+    auth_header_names: Optional[Any] = None,
     **kwargs: Any,
 ) -> AsyncIterator[Any]:
     """Issue an aiohttp request that re-validates every redirect hop.
@@ -290,6 +297,12 @@ async def safe_request_with_redirects(
     ensure_secure_url(url, context=context)
     # We control redirect behavior ourselves; refuse to let callers override.
     kwargs.pop("allow_redirects", None)
+
+    extra_auth_header_names = frozenset(
+        n.lower()
+        for n in (auth_header_names or [])
+        if isinstance(n, str)
+    )
 
     current_url = url
     current_method = method
@@ -335,7 +348,9 @@ async def safe_request_with_redirects(
 
             # Strip auth-bearing kwargs on cross-origin redirect.
             if not _same_origin(current_url, next_url):
-                _scrub_cross_origin_credentials(kwargs)
+                _scrub_cross_origin_credentials(
+                    kwargs, extra_auth_header_names
+                )
 
             if response.status == 303:
                 current_method = "GET"

--- a/plugins/communication_protocols/http/pyproject.toml
+++ b/plugins/communication_protocols/http/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp-http"
-version = "1.1.6"
+version = "1.1.7"
 authors = [
   { name = "UTCP Contributors" },
 ]

--- a/plugins/communication_protocols/http/src/utcp_http/_security.py
+++ b/plugins/communication_protocols/http/src/utcp_http/_security.py
@@ -284,7 +284,10 @@ def _same_origin(a: str, b: str) -> bool:
         return False
 
 
-def _scrub_cross_origin_credentials(kwargs: dict) -> None:
+def _scrub_cross_origin_credentials(
+    kwargs: dict,
+    extra_auth_header_names: Optional[frozenset] = None,
+) -> None:
     """Strip auth-bearing kwargs in place when crossing origins.
 
     Aligns the redirect helper with browser / requests / curl
@@ -314,6 +317,7 @@ def _scrub_cross_origin_credentials(kwargs: dict) -> None:
     Callers invoke this BEFORE issuing the next hop, only when the
     redirect target's origin differs from the current URL's origin.
     """
+    extra = extra_auth_header_names or frozenset()
     headers = kwargs.get("headers")
     if headers is not None:
         # Build a new dict so we never mutate the caller's headers
@@ -321,6 +325,11 @@ def _scrub_cross_origin_credentials(kwargs: dict) -> None:
         scrubbed: Dict[str, Any] = {}
         for k, v in dict(headers).items():
             if _header_is_auth_sensitive(k):
+                continue
+            # Strip caller-configured custom auth header names
+            # (e.g. ``ApiKeyAuth`` with ``var_name="X-MyApp"``)
+            # that don't match the auth-pattern regex on their own.
+            if isinstance(k, str) and k.lower() in extra:
                 continue
             scrubbed[k] = v
         kwargs["headers"] = scrubbed
@@ -351,6 +360,7 @@ async def safe_request_with_redirects(
     *,
     context: str,
     max_redirects: int = 5,
+    auth_header_names: Optional[Any] = None,
     **kwargs: Any,
 ) -> AsyncIterator[Any]:
     """Issue an aiohttp request that re-validates every redirect hop.
@@ -387,6 +397,22 @@ async def safe_request_with_redirects(
     ensure_secure_url(url, context=context)
     # We control redirect behavior ourselves; refuse to let callers override.
     kwargs.pop("allow_redirects", None)
+
+    # Pull caller-configured auth header names so the cross-origin
+    # scrub can strip them too. Private contract -- callers attach
+    # this via ``_apply_auth`` to declare which header names they
+    # populated with a secret. Never sent on the wire.
+    # ``auth_header_names`` is the explicit declaration of which
+    # header names the caller populated with a secret. Used to extend
+    # the cross-origin scrub beyond the canonical set so a
+    # custom-named API-key header (e.g. ``X-MyApp``) configured via
+    # ``ApiKeyAuth`` / ``OAuth2UserAuth`` is also stripped on
+    # cross-origin redirect.
+    extra_auth_header_names = frozenset(
+        n.lower()
+        for n in (auth_header_names or [])
+        if isinstance(n, str)
+    )
 
     current_url = url
     current_method = method
@@ -437,7 +463,9 @@ async def safe_request_with_redirects(
             # API key would be forwarded along. Mirrors browser /
             # requests / curl behaviour.
             if not _same_origin(current_url, next_url):
-                _scrub_cross_origin_credentials(kwargs)
+                _scrub_cross_origin_credentials(
+                    kwargs, extra_auth_header_names
+                )
 
             if response.status == 303:
                 current_method = "GET"

--- a/plugins/communication_protocols/http/src/utcp_http/http_communication_protocol.py
+++ b/plugins/communication_protocols/http/src/utcp_http/http_communication_protocol.py
@@ -76,20 +76,45 @@ class HttpCommunicationProtocol(CommunicationProtocol):
         self._session: Optional[aiohttp.ClientSession] = None
         self._oauth_tokens: Dict[str, Dict[str, Any]] = {}
     
+    @staticmethod
+    def _assert_no_crlf(value: Optional[str], field_name: str) -> None:
+        """Refuse CR/LF in attacker-influenceable strings that will land
+        in HTTP headers. aiohttp blocks these at request time, but
+        keeping the trust boundary inside UTCP means a transport swap
+        cannot silently regress.
+        """
+        if not isinstance(value, str):
+            return
+        if "\r" in value or "\n" in value:
+            raise ValueError(
+                f"Refusing to construct request: {field_name} contains CR/LF, "
+                f"which would enable HTTP header injection."
+            )
+
     def _apply_auth(self, provider: HttpCallTemplate, headers: Dict[str, str], query_params: Dict[str, Any]) -> tuple:
         """Apply authentication to the request based on the provider's auth configuration.
-        
+
         Returns:
-            tuple: (auth_obj, cookies) where auth_obj is for aiohttp basic auth and cookies is a dict
+            tuple ``(auth_obj, cookies, auth_header_names)``:
+              * ``auth_obj``: aiohttp BasicAuth for HTTP basic, or None.
+              * ``cookies``: dict of cookies to attach.
+              * ``auth_header_names``: list of header names that
+                received a secret. Threaded into
+                ``safe_request_with_redirects`` so a custom-named auth
+                header (e.g. ``ApiKeyAuth(var_name="X-MyApp")``) is
+                also stripped on cross-origin redirect.
         """
         auth = None
         cookies = {}
-        
+        auth_header_names: List[str] = []
+
         if provider.auth:
             if isinstance(provider.auth, ApiKeyAuth):
                 if provider.auth.api_key:
+                    self._assert_no_crlf(provider.auth.var_name, "ApiKeyAuth.var_name")
                     if provider.auth.location == "header":
                         headers[provider.auth.var_name] = provider.auth.api_key
+                        auth_header_names.append(provider.auth.var_name)
                     elif provider.auth.location == "query":
                         query_params[provider.auth.var_name] = provider.auth.api_key
                     elif provider.auth.location == "cookie":
@@ -97,16 +122,19 @@ class HttpCommunicationProtocol(CommunicationProtocol):
                 else:
                     logger.error("API key not found for ApiKeyAuth.")
                     raise ValueError("API key for ApiKeyAuth not found.")
-            
+
             elif isinstance(provider.auth, BasicAuth):
                 auth = AiohttpBasicAuth(provider.auth.username, provider.auth.password)
-            
+
             elif isinstance(provider.auth, OAuth2Auth):
                 # OAuth2 tokens are always sent in the Authorization header
-                # We'll handle this separately since it requires async token retrieval
-                pass
-        
-        return auth, cookies
+                # We'll handle this separately since it requires async token retrieval.
+                # We DO declare ``Authorization`` here so the scrubber treats
+                # the resulting bearer header as cross-origin-sensitive even
+                # if it slipped past the regex.
+                auth_header_names.append("Authorization")
+
+        return auth, cookies, auth_header_names
 
     async def register_manual(self, caller, manual_call_template: CallTemplate) -> RegisterManualResult:
         """REQUIRED
@@ -136,7 +164,7 @@ class HttpCommunicationProtocol(CommunicationProtocol):
             query_params = {}
             
             # Handle authentication
-            auth, cookies = self._apply_auth(manual_call_template, request_headers, query_params)
+            auth, cookies, auth_header_names = self._apply_auth(manual_call_template, request_headers, query_params)
             
             # Handle OAuth2 separately since it requires async token retrieval
             if manual_call_template.auth and isinstance(manual_call_template.auth, OAuth2Auth):
@@ -180,6 +208,7 @@ class HttpCommunicationProtocol(CommunicationProtocol):
                         data=data,
                         cookies=cookies,
                         timeout=aiohttp.ClientTimeout(total=10.0),
+                        auth_header_names=auth_header_names,
                     ) as response:
                         response.raise_for_status()  # Raise exception for 4XX/5XX responses
 
@@ -288,7 +317,7 @@ class HttpCommunicationProtocol(CommunicationProtocol):
         query_params = remaining_args
 
         # Handle authentication
-        auth, cookies = self._apply_auth(tool_call_template, request_headers, query_params)
+        auth, cookies, auth_header_names = self._apply_auth(tool_call_template, request_headers, query_params)
         
         # Handle OAuth2 separately since it requires async token retrieval
         if tool_call_template.auth and isinstance(tool_call_template.auth, OAuth2Auth):
@@ -328,6 +357,7 @@ class HttpCommunicationProtocol(CommunicationProtocol):
                     data=data,
                     cookies=cookies,
                     timeout=aiohttp.ClientTimeout(total=30.0),
+                    auth_header_names=auth_header_names,
                 ) as response:
                     response.raise_for_status()
                     

--- a/plugins/communication_protocols/http/src/utcp_http/sse_communication_protocol.py
+++ b/plugins/communication_protocols/http/src/utcp_http/sse_communication_protocol.py
@@ -38,20 +38,33 @@ class SseCommunicationProtocol(CommunicationProtocol):
     def __init__(self, logger: Optional[Callable[[str], None]] = None):
         self._oauth_tokens: Dict[str, Dict[str, Any]] = {}
 
+    @staticmethod
+    def _assert_no_crlf(value: Optional[str], field_name: str) -> None:
+        if not isinstance(value, str):
+            return
+        if "\r" in value or "\n" in value:
+            raise ValueError(
+                f"Refusing to construct request: {field_name} contains CR/LF, "
+                f"which would enable HTTP header injection."
+            )
+
     def _apply_auth(self, provider: SseCallTemplate, headers: Dict[str, str], query_params: Dict[str, Any]) -> tuple:
         """Apply authentication to the request based on the provider's auth configuration.
-        
+
         Returns:
-            tuple: (auth_obj, cookies) where auth_obj is for aiohttp basic auth and cookies is a dict
+            tuple ``(auth_obj, cookies, auth_header_names)``.
         """
         auth = None
         cookies = {}
-        
+        auth_header_names: List[str] = []
+
         if provider.auth:
             if isinstance(provider.auth, ApiKeyAuth):
                 if provider.auth.api_key:
+                    self._assert_no_crlf(provider.auth.var_name, "ApiKeyAuth.var_name")
                     if provider.auth.location == "header":
                         headers[provider.auth.var_name] = provider.auth.api_key
+                        auth_header_names.append(provider.auth.var_name)
                     elif provider.auth.location == "query":
                         query_params[provider.auth.var_name] = provider.auth.api_key
                     elif provider.auth.location == "cookie":
@@ -59,16 +72,16 @@ class SseCommunicationProtocol(CommunicationProtocol):
                 else:
                     logger.error("API key not found for ApiKeyAuth.")
                     raise ValueError("API key for ApiKeyAuth not found.")
-            
+
             elif isinstance(provider.auth, BasicAuth):
                 auth = AiohttpBasicAuth(provider.auth.username, provider.auth.password)
-            
+
             elif isinstance(provider.auth, OAuth2Auth):
-                # OAuth2 tokens are always sent in the Authorization header
-                # We'll handle this separately since it requires async token retrieval
-                pass
-        
-        return auth, cookies
+                # OAuth2 tokens are always sent in the Authorization header.
+                # Declared so cross-origin scrub recognises it.
+                auth_header_names.append("Authorization")
+
+        return auth, cookies, auth_header_names
 
     async def register_manual(self, caller, manual_call_template: CallTemplate) -> RegisterManualResult:
         """REQUIRED
@@ -90,7 +103,7 @@ class SseCommunicationProtocol(CommunicationProtocol):
             
             # Handle authentication
             query_params: Dict[str, Any] = {}
-            auth, cookies = self._apply_auth(manual_call_template, request_headers, query_params)
+            auth, cookies, auth_header_names = self._apply_auth(manual_call_template, request_headers, query_params)
 
             # Handle OAuth2 separately as it's async
             if isinstance(manual_call_template.auth, OAuth2Auth):
@@ -133,6 +146,7 @@ class SseCommunicationProtocol(CommunicationProtocol):
                     json=json_data,
                     data=data,
                     timeout=aiohttp.ClientTimeout(total=10.0),
+                    auth_header_names=auth_header_names,
                 ) as response:
                     response.raise_for_status()
                     response_data = await response.json()
@@ -199,7 +213,11 @@ class SseCommunicationProtocol(CommunicationProtocol):
         query_params = remaining_args
 
         # Handle authentication
-        auth, cookies = self._apply_auth(tool_call_template, request_headers, query_params)
+        # ``auth_header_names`` unused in the streaming path because
+        # SSE handshake uses ``allow_redirects=False`` -- there is no
+        # redirect chain to scrub. Reserved for future use if
+        # streaming ever supports per-hop validation.
+        auth, cookies, _auth_header_names = self._apply_auth(tool_call_template, request_headers, query_params)
 
         # Handle OAuth2 separately as it's async
         if isinstance(tool_call_template.auth, OAuth2Auth):

--- a/plugins/communication_protocols/http/src/utcp_http/streamable_http_communication_protocol.py
+++ b/plugins/communication_protocols/http/src/utcp_http/streamable_http_communication_protocol.py
@@ -35,20 +35,33 @@ class StreamableHttpCommunicationProtocol(CommunicationProtocol):
     def __init__(self):
         self._oauth_tokens: Dict[str, Dict[str, Any]] = {}
 
+    @staticmethod
+    def _assert_no_crlf(value: Optional[str], field_name: str) -> None:
+        if not isinstance(value, str):
+            return
+        if "\r" in value or "\n" in value:
+            raise ValueError(
+                f"Refusing to construct request: {field_name} contains CR/LF, "
+                f"which would enable HTTP header injection."
+            )
+
     def _apply_auth(self, provider: StreamableHttpCallTemplate, headers: Dict[str, str], query_params: Dict[str, Any]) -> tuple:
         """Apply authentication to the request based on the provider's auth configuration.
-        
+
         Returns:
-            tuple: (auth_obj, cookies) where auth_obj is for aiohttp basic auth and cookies is a dict
+            tuple ``(auth_obj, cookies, auth_header_names)``.
         """
         auth = None
         cookies = {}
-        
+        auth_header_names: List[str] = []
+
         if provider.auth:
             if isinstance(provider.auth, ApiKeyAuth):
                 if provider.auth.api_key:
+                    self._assert_no_crlf(provider.auth.var_name, "ApiKeyAuth.var_name")
                     if provider.auth.location == "header":
                         headers[provider.auth.var_name] = provider.auth.api_key
+                        auth_header_names.append(provider.auth.var_name)
                     elif provider.auth.location == "query":
                         query_params[provider.auth.var_name] = provider.auth.api_key
                     elif provider.auth.location == "cookie":
@@ -56,16 +69,14 @@ class StreamableHttpCommunicationProtocol(CommunicationProtocol):
                 else:
                     logger.error("API key not found for ApiKeyAuth.")
                     raise ValueError("API key for ApiKeyAuth not found.")
-            
+
             elif isinstance(provider.auth, BasicAuth):
                 auth = AiohttpBasicAuth(provider.auth.username, provider.auth.password)
-            
+
             elif isinstance(provider.auth, OAuth2Auth):
-                # OAuth2 tokens are always sent in the Authorization header
-                # We'll handle this separately since it requires async token retrieval
-                pass
-        
-        return auth, cookies
+                auth_header_names.append("Authorization")
+
+        return auth, cookies, auth_header_names
 
     async def close(self):
         """Close all active connections and clear internal state."""
@@ -93,7 +104,7 @@ class StreamableHttpCommunicationProtocol(CommunicationProtocol):
             
             # Handle authentication
             query_params: Dict[str, Any] = {}
-            auth, cookies = self._apply_auth(manual_call_template, request_headers, query_params)
+            auth, cookies, auth_header_names = self._apply_auth(manual_call_template, request_headers, query_params)
             
             # Handle OAuth2 separately as it's async
             if isinstance(manual_call_template.auth, OAuth2Auth):
@@ -136,6 +147,7 @@ class StreamableHttpCommunicationProtocol(CommunicationProtocol):
                     json=json_data,
                     data=data,
                     timeout=aiohttp.ClientTimeout(total=10.0),
+                    auth_header_names=auth_header_names,
                 ) as response:
                     response.raise_for_status()
                     response_data = await response.json()
@@ -228,7 +240,9 @@ class StreamableHttpCommunicationProtocol(CommunicationProtocol):
         query_params = remaining_args
 
         # Handle authentication
-        auth_handler, cookies = self._apply_auth(tool_call_template, request_headers, query_params)
+        # ``auth_header_names`` unused here -- streaming handshake uses
+        # ``allow_redirects=False`` (no redirect chain to scrub).
+        auth_handler, cookies, _auth_header_names = self._apply_auth(tool_call_template, request_headers, query_params)
 
         # Handle OAuth2 separately as it's async
         if isinstance(tool_call_template.auth, OAuth2Auth):

--- a/plugins/communication_protocols/http/tests/test_redirect_security.py
+++ b/plugins/communication_protocols/http/tests/test_redirect_security.py
@@ -82,6 +82,88 @@ class TestSameOriginHelper:
         assert _same_origin(a, b) is False
 
 
+class TestAuthHeaderNamesThreadedToScrub:
+    """Pin the explicit ``auth_header_names`` channel that lets the
+    redirect helper strip caller-configured auth header names (e.g.
+    ``ApiKeyAuth(var_name="X-MyApp")``) on cross-origin redirect --
+    such names don't match the auth-pattern regex and would otherwise
+    survive the scrub.
+    """
+
+    @pytest.mark.asyncio
+    async def test_custom_auth_header_name_stripped_via_explicit_list(
+        self, aiohttp_server
+    ) -> None:
+        captured: dict = {}
+
+        async def _capture(request: web.Request) -> web.Response:
+            captured["x_myapp"] = request.headers.get("X-MyApp")
+            return web.json_response({"ok": True})
+
+        target_app = web.Application()
+        target_app.router.add_get("/landed", _capture)
+        target = await aiohttp_server(target_app)
+
+        async def _redirect(request: web.Request) -> web.Response:
+            raise web.HTTPFound(str(target.make_url("/landed")))
+
+        attacker_app = web.Application()
+        attacker_app.router.add_get("/tool", _redirect)
+        attacker = await aiohttp_server(attacker_app)
+
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            async with safe_request_with_redirects(
+                session,
+                "GET",
+                str(attacker.make_url("/tool")),
+                context="tool invocation",
+                headers={"X-MyApp": "secret-key"},
+                auth_header_names=["X-MyApp"],
+            ):
+                pass
+
+        assert captured["x_myapp"] is None, (
+            "Caller-declared auth header name leaked cross-origin -- the "
+            "explicit auth_header_names channel did not extend the scrub."
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_auth_header_kept_on_same_origin(
+        self, aiohttp_server
+    ) -> None:
+        captured: dict = {}
+
+        async def _capture(request: web.Request) -> web.Response:
+            captured["x_myapp"] = request.headers.get("X-MyApp")
+            return web.json_response({"ok": True})
+
+        async def _redirect(request: web.Request) -> web.Response:
+            raise web.HTTPFound("/landed")
+
+        app = web.Application()
+        app.router.add_get("/start", _redirect)
+        app.router.add_get("/landed", _capture)
+        server = await aiohttp_server(app)
+
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            async with safe_request_with_redirects(
+                session,
+                "GET",
+                str(server.make_url("/start")),
+                context="tool invocation",
+                headers={"X-MyApp": "secret-key"},
+                auth_header_names=["X-MyApp"],
+            ):
+                pass
+
+        # Same-origin: keep the auth header.
+        assert captured["x_myapp"] == "secret-key"
+
+
 class TestAuthHeaderClassifier:
     """Direct unit tests for ``_header_is_auth_sensitive``. The
     cross-origin integration tests cover the end-to-end scrub
@@ -505,6 +587,40 @@ class TestCallToolRedirectExfiltration:
 # OAuth2 token URL must be validated before any credential bytes leave
 # the process.
 # ---------------------------------------------------------------------------
+
+
+class TestCrlfHeaderInjectionRejected:
+    """Defense-in-depth: refuse CR/LF in attacker-influenceable strings
+    that will land in HTTP headers. aiohttp blocks these at request
+    time, but enforcing inside UTCP means a transport swap cannot
+    silently regress.
+    """
+
+    @pytest.mark.parametrize(
+        "var_name",
+        [
+            "X-Api-Key\r\nX-Injected: yes",
+            "X-Foo\nX-Other: bar",
+            "X-Foo\rX-Other: bar",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_apikey_with_crlf_var_name_rejected(self, var_name: str) -> None:
+        from utcp.data.auth_implementations.api_key_auth import ApiKeyAuth
+
+        proto = HttpCommunicationProtocol()
+        tpl = HttpCallTemplate(
+            name="x",
+            url="https://api.example.com/x",
+            http_method="GET",
+            auth=ApiKeyAuth(
+                api_key="secret",
+                var_name=var_name,
+                location="header",
+            ),
+        )
+        with pytest.raises(ValueError, match="CR/LF"):
+            await proto.call_tool(None, "x", {}, tpl)
 
 
 class TestOAuth2TokenUrlValidation:

--- a/plugins/communication_protocols/websocket/pyproject.toml
+++ b/plugins/communication_protocols/websocket/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp-websocket"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
   { name = "UTCP Contributors" },
 ]

--- a/plugins/communication_protocols/websocket/src/utcp_websocket/_security.py
+++ b/plugins/communication_protocols/websocket/src/utcp_websocket/_security.py
@@ -274,16 +274,22 @@ def _same_origin(a: str, b: str) -> bool:
         return False
 
 
-def _scrub_cross_origin_credentials(kwargs: dict) -> None:
+def _scrub_cross_origin_credentials(
+    kwargs: dict,
+    extra_auth_header_names: Optional[frozenset] = None,
+) -> None:
     """Strip auth-bearing kwargs in place when crossing origins.
 
     Mirrors ``utcp_http._security._scrub_cross_origin_credentials``.
     """
+    extra = extra_auth_header_names or frozenset()
     headers = kwargs.get("headers")
     if headers is not None:
         scrubbed: Dict[str, Any] = {}
         for k, v in dict(headers).items():
             if _header_is_auth_sensitive(k):
+                continue
+            if isinstance(k, str) and k.lower() in extra:
                 continue
             scrubbed[k] = v
         kwargs["headers"] = scrubbed
@@ -304,6 +310,7 @@ async def safe_request_with_redirects(
     *,
     context: str,
     max_redirects: int = 5,
+    auth_header_names: Optional[Any] = None,
     **kwargs: Any,
 ) -> AsyncIterator[Any]:
     """Issue an aiohttp request that re-validates every redirect hop.
@@ -340,6 +347,12 @@ async def safe_request_with_redirects(
     ensure_secure_url(url, context=context)
     # We control redirect behavior ourselves; refuse to let callers override.
     kwargs.pop("allow_redirects", None)
+
+    extra_auth_header_names = frozenset(
+        n.lower()
+        for n in (auth_header_names or [])
+        if isinstance(n, str)
+    )
 
     current_url = url
     current_method = method
@@ -385,7 +398,9 @@ async def safe_request_with_redirects(
 
             # Strip auth-bearing kwargs on cross-origin redirect.
             if not _same_origin(current_url, next_url):
-                _scrub_cross_origin_credentials(kwargs)
+                _scrub_cross_origin_credentials(
+                    kwargs, extra_auth_header_names
+                )
 
             if response.status == 303:
                 current_method = "GET"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened redirect and header handling across `http`, `gql`, and `websocket` to prevent credential leaks and header injection. Custom auth headers are now stripped on cross‑origin redirects, and CR/LF in header names is rejected.

- **Bug Fixes**
  - Strip caller-declared auth headers on cross-origin redirects via new `auth_header_names` threaded from `_apply_auth` (covers `ApiKeyAuth` custom header names and `Authorization` for OAuth2).
  - Preserve headers on same-origin redirects; added tests to pin behavior.
  - Reject CR/LF in attacker-controlled header fields (e.g., `ApiKeyAuth.var_name`) to block HTTP header injection in HTTP/SSE/streamable HTTP paths.
  - Implemented in `safe_request_with_redirects` for `utcp-http`, `utcp-gql`, and `utcp-websocket`; new param is internal-only and not sent on the wire.

- **Dependencies**
  - Bump `utcp-http` to `1.1.7`, `utcp-gql` to `1.1.4`, `utcp-websocket` to `1.1.4`.

<sup>Written for commit f6f51e9bc55b6906f20141f1afa63c9295e438b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/python-utcp/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

