### PR TITLE
Add Xquik OpenAPI ingestion example

### DIFF
--- a/docs/openapi-ingestion.md
+++ b/docs/openapi-ingestion.md
@@ -53,6 +53,40 @@ async def load_remote_spec(url):
 manual = await load_remote_spec("https://api.example.com/openapi.json")
 ```
 
+### Xquik API Example
+
+Xquik publishes an OpenAPI 3.1 specification for its X data API at
+`https://xquik.com/openapi.json`. It can be loaded the same way as any other
+remote OpenAPI document:
+
+```python
+manual = await load_remote_spec("https://xquik.com/openapi.json")
+
+print(f"Generated {len(manual.tools)} Xquik tools")
+```
+
+When calling authenticated endpoints, provide the API key through the
+`x-api-key` header and keep the value in an injected variable:
+
+```python
+config = {
+    "manual_call_templates": [
+        {
+            "name": "xquik",
+            "call_template_type": "http",
+            "url": "https://xquik.com/openapi.json",
+            "http_method": "GET",
+            "auth": {
+                "auth_type": "api_key",
+                "api_key": "${XQUIK_API_KEY}",
+                "var_name": "x-api-key",
+                "location": "header"
+            }
+        }
+    ]
+}
+```
+
 ## Method 3: UTCP Client Configuration
 
 Include OpenAPI specs directly in your UTCP client configuration.

--- a/docs/openapi-ingestion.md
+++ b/docs/openapi-ingestion.md
@@ -1,6 +1,6 @@
 # OpenAPI Ingestion Methods in python-utcp
 
-UTCP automatically converts OpenAPI 2.0/3.0 specifications into UTCP tools, enabling AI agents to interact with REST APIs without requiring server modifications or additional infrastructure.
+UTCP automatically converts OpenAPI 2.0/3.0/3.1 specifications into UTCP tools, enabling AI agents to interact with REST APIs without requiring server modifications or additional infrastructure.
 
 ## Method 1: Direct OpenAPI Converter
 
@@ -170,7 +170,7 @@ OpenAPI security schemes automatically convert to UTCP auth objects:
 - `oauth2` → `OAuth2Auth`
 
 ### Multi-format Support
-- **OpenAPI 2.0 & 3.0**: Full compatibility
+- **OpenAPI 2.0, 3.0 & 3.1**: Full compatibility
 - **JSON & YAML**: Automatic format detection
 - **Local & Remote**: Files or URLs
 

--- a/docs/openapi-ingestion.md
+++ b/docs/openapi-ingestion.md
@@ -1,6 +1,6 @@
 # OpenAPI Ingestion Methods in python-utcp
 
-UTCP automatically converts OpenAPI 2.0/3.0/3.1 specifications into UTCP tools, enabling AI agents to interact with REST APIs without requiring server modifications or additional infrastructure.
+UTCP automatically converts OpenAPI 2.0/3.0 specifications, plus compatible OpenAPI 3.1 specifications, into UTCP tools, enabling AI agents to interact with REST APIs without requiring server modifications or additional infrastructure.
 
 ## Method 1: Direct OpenAPI Converter
 
@@ -170,7 +170,8 @@ OpenAPI security schemes automatically convert to UTCP auth objects:
 - `oauth2` → `OAuth2Auth`
 
 ### Multi-format Support
-- **OpenAPI 2.0, 3.0 & 3.1**: Full compatibility
+- **OpenAPI 2.0 & 3.0**: Full compatibility
+- **OpenAPI 3.1**: Compatible specifications can be loaded, but verify 3.1-specific schema features against the converter
 - **JSON & YAML**: Automatic format detection
 - **Local & Remote**: Files or URLs
 


### PR DESCRIPTION
## Summary

Adds a concrete Xquik example to the OpenAPI ingestion docs. Xquik exposes an OpenAPI 3.1 spec at https://xquik.com/openapi.json and uses the `x-api-key` header for API key authentication, so it fits the existing remote OpenAPI and API key examples.

## Validation

- Confirmed `https://xquik.com/openapi.json` returns HTTP 200 with JSON.
- Checked the public OpenAPI security scheme for the `x-api-key` header.
- Ran `git diff --check`.

## Duplicate Check

- Searched all-state PRs and issues for Xquik and xquik.com references before opening this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Xquik example to the OpenAPI ingestion docs and refine wording around OpenAPI 3.1 compatibility. The example loads `https://xquik.com/openapi.json`, uses the `x-api-key` header with Python and UTCP `manual_call_templates`, and notes that only compatible 3.1 specs are supported and 3.1-specific features should be verified.

<sup>Written for commit c01cf6522fbfd38f1031b247c4f70b8e4ca92e81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/python-utcp/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

