### PR TITLE
feat(core): add explicit examples field to JsonSchema

### DIFF
--- a/core/src/utcp/data/tool.py
+++ b/core/src/utcp/data/tool.py
@@ -38,6 +38,7 @@ class JsonSchema(BaseModel):
         default: Optional schema default value.
         format: Optional schema format.
         additionalProperties: Optional schema additional properties.
+        examples: Optional list of example values for the schema.
     """
     schema_: Optional[str] = Field(None, alias="$schema")
     id_: Optional[str] = Field(None, alias="$id")
@@ -50,6 +51,7 @@ class JsonSchema(BaseModel):
     enum: Optional[List[JsonType]] = None
     const: Optional[JsonType] = None
     default: Optional[JsonType] = None
+    examples: Optional[List[JsonType]] = None
     format: Optional[str] = None
     additionalProperties: Optional[Union[bool, "JsonSchema"]] = None
     pattern: Optional[str] = None

--- a/core/tests/data/test_tool_schema.py
+++ b/core/tests/data/test_tool_schema.py
@@ -1,0 +1,38 @@
+"""Tests for the JsonSchema model, including the `examples` field."""
+
+from utcp.data.tool import JsonSchema, JsonSchemaSerializer
+
+
+def test_jsonschema_examples_field_is_typed():
+    """`examples` is a declared field, not just an extra attribute."""
+    assert "examples" in JsonSchema.model_fields
+
+    schema = JsonSchema(type="string", examples=["user123", "user456"])
+    assert schema.examples == ["user123", "user456"]
+
+
+def test_jsonschema_examples_default_none():
+    """`examples` defaults to None when absent."""
+    schema = JsonSchema(type="string")
+    assert schema.examples is None
+
+
+def test_jsonschema_examples_roundtrip():
+    """`examples` survives serialize -> validate roundtrip."""
+    serializer = JsonSchemaSerializer()
+    schema = JsonSchema(
+        type="object",
+        examples=[{"id": "user123", "name": "John Doe"}],
+    )
+
+    as_dict = serializer.to_dict(schema)
+    assert as_dict["examples"] == [{"id": "user123", "name": "John Doe"}]
+
+    restored = serializer.validate_dict(as_dict)
+    assert restored.examples == schema.examples
+
+
+def test_jsonschema_examples_allows_mixed_json_types():
+    """`examples` accepts any JSON value (string, bool, number, object)."""
+    schema = JsonSchema(examples=["a", True, 1, 1.5, None, {"k": "v"}, [1, 2]])
+    assert schema.examples == ["a", True, 1, 1.5, None, {"k": "v"}, [1, 2]]


### PR DESCRIPTION
## What

Declares `examples` as a first-class field on `JsonSchema`:

```python
examples: Optional[List[JsonType]] = None
```

## Why

`JsonSchema` previously accepted `examples` only via `model_config extra="allow"`. That works at runtime but leaves the field:
- **untyped** — no validation, type checkers blind to it
- **undocumented** — missing from the docstring `Attributes`
- **fragile** — relies on extra-field behavior that could change

This is the JSON Schema `examples` keyword and belongs in the model explicitly.

## Context

Follow-up to #88 (OpenAPI converter examples parsing), which currently depends on the extra-field fallback to carry parsed examples through. With this field declared, that feature rests on a real, validated contract.

## Tests

Adds `core/tests/data/test_tool_schema.py`:
- field is declared in `model_fields`
- defaults to `None`
- survives serialize → validate roundtrip
- accepts mixed JSON value types

All 4 pass. No serialization change (`model_dump(by_alias=True)` already included extra fields; now it's a declared one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit `examples: Optional[List[JsonType]]` field to `JsonSchema` so the JSON Schema `examples` keyword is typed, validated, and documented. This removes reliance on `extra="allow"`, keeps serialization unchanged, and stabilizes the OpenAPI converter’s examples parsing.

<sup>Written for commit e31be05f8278b038cdf698b368d6da9f7f3c0c2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/python-utcp/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

