### PR TITLE
fix(openapi): make unsupported-method warning reachable

### DIFF
--- a/plugins/communication_protocols/http/pyproject.toml
+++ b/plugins/communication_protocols/http/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp-http"
-version = "1.1.8"
+version = "1.1.9"
 authors = [
   { name = "UTCP Contributors" },
 ]

--- a/plugins/communication_protocols/http/src/utcp_http/openapi_converter.py
+++ b/plugins/communication_protocols/http/src/utcp_http/openapi_converter.py
@@ -29,9 +29,15 @@ from utcp.data.tool import Tool, JsonSchema
 from utcp_http.http_call_template import HttpCallTemplate
 from utcp_http._security import ensure_secure_url, is_loopback_url
 
-# HTTP methods that HttpCallTemplate.http_method accepts. Kept as the single
-# source of truth for both the operation loop filter and per-operation
-# validation so the two can never drift apart.
+# All HTTP methods that OpenAPI defines as operation fields on a Path Item
+# Object. The conversion loop uses this to tell operations apart from the other
+# path-item keys (parameters, summary, $ref, servers, ...), so that genuinely
+# unsupported operations still reach _create_tool and get a warning rather than
+# being silently dropped by the loop.
+OPENAPI_OPERATION_METHODS: Tuple[str, ...] = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
+
+# The subset of HTTP methods that HttpCallTemplate.http_method accepts.
+# _create_tool validates against this and skips anything else with a warning.
 SUPPORTED_HTTP_METHODS: Tuple[str, ...] = ("GET", "POST", "PUT", "DELETE", "PATCH")
 
 class OpenApiConverter:
@@ -190,7 +196,7 @@ class OpenApiConverter:
 
         for path, path_item in self.spec.get("paths", {}).items():
             for method, operation in path_item.items():
-                if method.upper() in SUPPORTED_HTTP_METHODS:
+                if method.lower() in OPENAPI_OPERATION_METHODS:
                     tool = self._create_tool(path, method, operation, base_url)
                     if tool:
                         tools.append(tool)

--- a/plugins/communication_protocols/http/tests/test_openapi_converter.py
+++ b/plugins/communication_protocols/http/tests/test_openapi_converter.py
@@ -220,7 +220,7 @@ def test_openapi_converter_parameter_examples():
     assert example_value["email"] == "jane@example.com"
 
 
-def test_openapi_converter_skips_unsupported_methods():
+def test_openapi_converter_skips_unsupported_methods(capsys):
     """Operations with HTTP methods HttpCallTemplate cannot represent are skipped, not crashed on."""
     openapi_spec = {
         "openapi": "3.0.0",
@@ -253,6 +253,13 @@ def test_openapi_converter_skips_unsupported_methods():
 
     tool_names = {tool.name for tool in manual.tools}
     assert tool_names == {"listThings"}
+
+    # Unsupported operations must reach _create_tool and emit a skip warning,
+    # not be silently dropped by the loop filter.
+    stderr = capsys.readouterr().err
+    assert "optionsThings" in stderr
+    assert "headThings" in stderr
+    assert "traceThings" in stderr
 
 
 def test_openapi_converter_schema_level_examples_normalized():


### PR DESCRIPTION
## Problem

P3 dead-code bug introduced in #88. `convert()` pre-filtered operations to `SUPPORTED_HTTP_METHODS`:

```python
if method.upper() in SUPPORTED_HTTP_METHODS:
    tool = self._create_tool(...)
```

So unsupported verbs (`options`/`head`/`trace`) never reached `_create_tool`, making its validation guard — and the intended skip warning — unreachable dead code.

## Root cause

The method check was duplicated: once in the loop filter, once in `_create_tool`. The loop filter excluded exactly the methods the inner guard was meant to warn about.

## Fix

Split into two sets:
- `OPENAPI_OPERATION_METHODS` (get/put/post/delete/options/head/patch/trace) — used by the loop only to tell operations apart from non-operation path-item keys (`parameters`, `summary`, `$ref`, `servers`).
- `SUPPORTED_HTTP_METHODS` (the call-template subset) — `_create_tool` validates against this and warns+skips anything else.

Now unsupported operations reach `_create_tool` and emit the warning instead of being silently dropped.

## Tests

Strengthened `test_openapi_converter_skips_unsupported_methods` to assert the warning is actually emitted (via `capsys`), not just that the tools are absent. Full converter suite: 5 passed.

Bumps `utcp-http` 1.1.8 → 1.1.9.

> Note: the same bug was ported to typescript-utcp; fixed there in PR #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dead-code path in the OpenAPI converter so unsupported HTTP methods emit a warning instead of being silently dropped. Ensures all OpenAPI operations reach validation while still skipping non-operation keys.

- **Bug Fixes**
  - Introduced `OPENAPI_OPERATION_METHODS` for loop filtering; kept `SUPPORTED_HTTP_METHODS` for `_create_tool` validation.
  - Loop now filters on `method.lower()` against OpenAPI operations; `_create_tool` warns and skips `options`, `head`, and `trace`.
  - Strengthened `test_openapi_converter_skips_unsupported_methods` to assert the warning via `capsys`.
  - Bumped `utcp-http` to `1.1.9`.

<sup>Written for commit a3bb75f3a618668cdc154a76778429f0b6bb7db4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/python-utcp/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

