### PR TITLE
Dev

### DIFF
--- a/plugins/communication_protocols/http/pyproject.toml
+++ b/plugins/communication_protocols/http/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp-http"
-version = "1.1.8"
+version = "1.1.9"
 authors = [
   { name = "UTCP Contributors" },
 ]

--- a/plugins/communication_protocols/http/src/utcp_http/openapi_converter.py
+++ b/plugins/communication_protocols/http/src/utcp_http/openapi_converter.py
@@ -29,9 +29,15 @@ from utcp.data.tool import Tool, JsonSchema
 from utcp_http.http_call_template import HttpCallTemplate
 from utcp_http._security import ensure_secure_url, is_loopback_url
 
-# HTTP methods that HttpCallTemplate.http_method accepts. Kept as the single
-# source of truth for both the operation loop filter and per-operation
-# validation so the two can never drift apart.
+# All HTTP methods that OpenAPI defines as operation fields on a Path Item
+# Object. The conversion loop uses this to tell operations apart from the other
+# path-item keys (parameters, summary, $ref, servers, ...), so that genuinely
+# unsupported operations still reach _create_tool and get a warning rather than
+# being silently dropped by the loop.
+OPENAPI_OPERATION_METHODS: Tuple[str, ...] = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
+
+# The subset of HTTP methods that HttpCallTemplate.http_method accepts.
+# _create_tool validates against this and skips anything else with a warning.
 SUPPORTED_HTTP_METHODS: Tuple[str, ...] = ("GET", "POST", "PUT", "DELETE", "PATCH")
 
 class OpenApiConverter:
@@ -190,7 +196,7 @@ class OpenApiConverter:
 
         for path, path_item in self.spec.get("paths", {}).items():
             for method, operation in path_item.items():
-                if method.upper() in SUPPORTED_HTTP_METHODS:
+                if method.lower() in OPENAPI_OPERATION_METHODS:
                     tool = self._create_tool(path, method, operation, base_url)
                     if tool:
                         tools.append(tool)

--- a/plugins/communication_protocols/http/tests/test_openapi_converter.py
+++ b/plugins/communication_protocols/http/tests/test_openapi_converter.py
@@ -220,7 +220,7 @@ def test_openapi_converter_parameter_examples():
     assert example_value["email"] == "jane@example.com"
 
 
-def test_openapi_converter_skips_unsupported_methods():
+def test_openapi_converter_skips_unsupported_methods(capsys):
     """Operations with HTTP methods HttpCallTemplate cannot represent are skipped, not crashed on."""
     openapi_spec = {
         "openapi": "3.0.0",
@@ -253,6 +253,13 @@ def test_openapi_converter_skips_unsupported_methods():
 
     tool_names = {tool.name for tool in manual.tools}
     assert tool_names == {"listThings"}
+
+    # Unsupported operations must reach _create_tool and emit a skip warning,
+    # not be silently dropped by the loop filter.
+    stderr = capsys.readouterr().err
+    assert "optionsThings" in stderr
+    assert "headThings" in stderr
+    assert "traceThings" in stderr
 
 
 def test_openapi_converter_schema_level_examples_normalized():


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix OpenAPI conversion so unsupported HTTP methods aren’t silently dropped; they now reach validation and emit a skip warning. Bumps `utcp-http` to 1.1.9.

- **Bug Fixes**
  - The conversion loop now recognizes all OpenAPI operation methods and ignores only non-operation path-item keys.
  - Method validation stays in the per-operation builder, which warns and skips unsupported methods.
  - Test updated to assert the warning is printed for options/head/trace.

<sup>Written for commit bb1ee06f8c150ea31ee7276f9dff0a8fe18c540e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/python-utcp/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

