### PR TITLE
fix(openapi): preserve array-form (JSON Schema / OAS 3.1) schema examples

### DIFF
--- a/plugins/communication_protocols/http/pyproject.toml
+++ b/plugins/communication_protocols/http/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp-http"
-version = "1.1.9"
+version = "1.1.10"
 authors = [
   { name = "UTCP Contributors" },
 ]

--- a/plugins/communication_protocols/http/src/utcp_http/openapi_converter.py
+++ b/plugins/communication_protocols/http/src/utcp_http/openapi_converter.py
@@ -360,20 +360,30 @@ class OpenApiConverter:
 
     def _extract_examples(self, obj: Dict[str, Any]) -> Optional[List[Any]]:
         """
-        Extract examples from an OpenAPI parameter or Media Type Object (Parameter, Media Type, Schema).
-        
-        Supports both 'example' (single value) and 'examples' (map of Example Objects).
+        Extract examples from an OpenAPI Parameter, Media Type, or Schema object.
+
+        Handles all three shapes the spec allows:
+          - 'example' (single value) - OpenAPI Parameter / Media Type / 3.0 Schema.
+          - 'examples' as a map of named Example Objects - OpenAPI Parameter /
+            Media Type Object (each entry carries an inline 'value').
+          - 'examples' as a list of literal values - JSON Schema / OpenAPI 3.1
+            Schema Object.
+
         Returns a list of example values suitable for JSON Schema 'examples' keyword.
         """
         examples = []
-        
+
         # Handle single 'example' field
         if "example" in obj and obj["example"] is not None:
             examples.append(obj["example"])
-        
-        # Handle 'examples' map (OpenAPI 3.0+)
-        if "examples" in obj and isinstance(obj["examples"], dict):
-            for example_obj in obj["examples"].values():
+
+        examples_obj = obj.get("examples")
+        if isinstance(examples_obj, list):
+            # JSON Schema / OpenAPI 3.1 Schema form: a plain list of example values.
+            examples.extend(examples_obj)
+        elif isinstance(examples_obj, dict):
+            # OpenAPI 3.0 form: a map of named Example Objects.
+            for example_obj in examples_obj.values():
                 if isinstance(example_obj, dict) and "$ref" in example_obj:
                     example_obj = self._resolve_ref_obj(example_obj, set()) or {}
                 if isinstance(example_obj, dict):

--- a/plugins/communication_protocols/http/tests/test_openapi_converter.py
+++ b/plugins/communication_protocols/http/tests/test_openapi_converter.py
@@ -316,3 +316,57 @@ def test_openapi_converter_schema_level_examples_normalized():
     assert "example" not in body_param.model_dump(by_alias=True)
 
     assert tool.outputs.examples == [{"id": "w_1"}]
+
+
+def test_openapi_converter_array_form_schema_examples():
+    """Array-form (JSON Schema / OpenAPI 3.1) schema 'examples' are preserved, not dropped."""
+    openapi_spec = {
+        "openapi": "3.1.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/gadgets": {
+                "post": {
+                    "operationId": "createGadget",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {"name": {"type": "string"}},
+                                    # JSON Schema 'examples' keyword: a list of values
+                                    "examples": [{"name": "Gadget A"}, {"name": "Gadget B"}],
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "ok",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "string",
+                                        "examples": ["ok", "done"],
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+    }
+
+    converter = OpenApiConverter(openapi_spec)
+    manual = converter.convert()
+
+    tool = next((t for t in manual.tools if t.name == "createGadget"), None)
+    assert tool is not None
+
+    body_param = tool.inputs.properties.get("body")
+    assert body_param is not None
+    assert body_param.examples == [{"name": "Gadget A"}, {"name": "Gadget B"}]
+    # examples surface in the normalized field on serialization
+    assert body_param.model_dump(by_alias=True).get("examples") == [{"name": "Gadget A"}, {"name": "Gadget B"}]
+
+    assert tool.outputs.examples == ["ok", "done"]


### PR DESCRIPTION
## Problem (P2)

Schema-level `examples` declared as a JSON Schema list were silently lost during conversion:

```jsonc
"schema": { "type": "string", "examples": ["ok", "done"] }   // -> dropped
```

## Root cause

`_extract_examples` only recognized `examples` as an OpenAPI **map** of named Example Objects (`isinstance(obj["examples"], dict)`), so it returned nothing for the list form. Meanwhile `_schema_without_example_keys` strips `examples` from the schema before it is spread onto the property. Before that strip the list passed through raw; after it (added when normalizing examples), the list is extracted as nothing **and** removed — net data loss. JSON Schema (and OpenAPI 3.1 schema objects) define `examples` as a list of values.

## Fix

`_extract_examples` now handles all three shapes:
- `example` (single value)
- `examples` as a map of Example Objects (OpenAPI 3.0) — `value` per entry, `$ref` resolved
- `examples` as a list of literal values (JSON Schema / OAS 3.1) — extended verbatim

The two forms can't collide: a media type object's `examples` is always a map, a schema's is always a list.

## Tests

New `test_openapi_converter_array_form_schema_examples` covering array-form schema examples on both request body and response. Full converter suite: 6 passed.

Bumps `utcp-http` 1.1.9 → 1.1.10.

> Note: same bug fixed in typescript-utcp (PR #29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves array-form schema `examples` (JSON Schema / OAS 3.1) in the OpenAPI converter. Prevents silent data loss so examples appear on request and response models.

- **Bug Fixes**
  - `_extract_examples` now supports single `example`, `examples` map (OAS 3.0, `$ref` resolved), and `examples` list (JSON Schema/OAS 3.1).
  - Added test covering array-form schema examples for request body and response.

- **Dependencies**
  - Bump `utcp-http` to `1.1.10`.

<sup>Written for commit 8b321458f87b55a6db033576f5e005af6c28ad25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/python-utcp/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

