### PR TITLE
fix(openapi): type-aware, order-insensitive example de-duplication

### DIFF
--- a/plugins/communication_protocols/http/pyproject.toml
+++ b/plugins/communication_protocols/http/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "utcp-http"
-version = "1.1.10"
+version = "1.1.11"
 authors = [
   { name = "UTCP Contributors" },
 ]

--- a/plugins/communication_protocols/http/src/utcp_http/openapi_converter.py
+++ b/plugins/communication_protocols/http/src/utcp_http/openapi_converter.py
@@ -401,13 +401,21 @@ class OpenApiConverter:
         Used to combine examples that can appear at more than one level for the
         same value, e.g. a Media Type Object and the Schema Object beneath it.
         Returns a list suitable for the JSON Schema 'examples' keyword, or None.
+
+        De-duplication uses a canonical JSON serialization (sorted keys) as the
+        identity. This is order-insensitive for objects and type-aware, so it
+        does not collapse semantically distinct examples the way Python's ``==``
+        would (``True == 1``, ``False == 0``, ``1 == 1.0``).
         """
         merged: List[Any] = []
+        seen: set = set()
         for obj in objs:
             if not isinstance(obj, dict):
                 continue
             for ex in self._extract_examples(obj) or []:
-                if ex not in merged:
+                key = json.dumps(ex, sort_keys=True, default=str)
+                if key not in seen:
+                    seen.add(key)
                     merged.append(ex)
         return merged or None
 

--- a/plugins/communication_protocols/http/tests/test_openapi_converter.py
+++ b/plugins/communication_protocols/http/tests/test_openapi_converter.py
@@ -370,3 +370,56 @@ def test_openapi_converter_array_form_schema_examples():
     assert body_param.model_dump(by_alias=True).get("examples") == [{"name": "Gadget A"}, {"name": "Gadget B"}]
 
     assert tool.outputs.examples == ["ok", "done"]
+
+
+def test_openapi_converter_example_dedup_is_type_aware_and_order_insensitive():
+    """De-dup keeps distinct JSON types (true vs 1) and collapses key-reordered objects."""
+    openapi_spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {
+            "/items": {
+                "post": {
+                    "operationId": "createItem",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                # media-type example with one key order...
+                                "examples": {"e1": {"value": {"a": 1, "b": 2}}},
+                                "schema": {
+                                    "type": "object",
+                                    # ...schema example with the other key order -> collapses to one
+                                    "examples": [{"b": 2, "a": 1}],
+                                },
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "ok",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        # true and 1 are distinct; duplicate true removed
+                                        "examples": [True, 1, True],
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+    }
+
+    converter = OpenApiConverter(openapi_spec)
+    manual = converter.convert()
+
+    tool = next((t for t in manual.tools if t.name == "createItem"), None)
+    assert tool is not None
+
+    # {a:1,b:2} and {b:2,a:1} are the same example -> collapsed to one
+    assert tool.inputs.properties.get("body").examples == [{"a": 1, "b": 2}]
+    # True vs 1 kept distinct (== would have collapsed them); duplicate True removed
+    assert tool.outputs.examples == [True, 1]


### PR DESCRIPTION
## Problem (P3, correctness + cross-impl divergence)

`_merge_examples` de-duplicated with `if ex not in merged`, which relies on Python `==`. So distinct JSON examples collapse:
- `True == 1`, `False == 0`, `1 == 1.0`

Mixing e.g. a media-type example `value: true` and a schema example `1` for the same field silently dropped one. It also diverged from the TypeScript implementation (which used `JSON.stringify` and had the opposite bug — key-order false negatives).

## Fix

Use a canonical JSON serialization (`json.dumps(ex, sort_keys=True, default=str)`) as the de-dup identity:
- **order-insensitive** for objects (`{a:1,b:2}` == `{b:2,a:1}`)
- **type-aware** for scalars (`true` ≠ `1`, `1` ≠ `1.0`)

This matches the corrected TypeScript behavior so both implementations produce identical output.

## Tests

New `test_openapi_converter_example_dedup_is_type_aware_and_order_insensitive`: asserts key-reordered objects collapse to one and `true`/`1` stay distinct. Full converter suite: 7 passed.

Bumps `utcp-http` 1.1.10 → 1.1.11.

> Found during a cross-repo audit of the examples implementation. Same fix in typescript-utcp (paired PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAPI example de-duplication to be type-aware and order-insensitive so distinct values aren’t dropped and outputs match the TypeScript implementation.

- **Bug Fixes**
  - De-duplicate using canonical JSON serialization (sorted keys) as identity.
  - Keeps JSON types distinct (true ≠ 1, 1 ≠ 1.0); collapses re-ordered object keys.
  - Aligns behavior with the TypeScript implementation for consistent output.

- **Dependencies**
  - Bump `utcp-http` to `1.1.11`.

<sup>Written for commit 3e00914b440fb68669554218bfae264dbf54e507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/python-utcp/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

