### PR TITLE
mcp: quiet stdio child stderr by default, tighten structuredContent unwrap

### DIFF
--- a/plugins/communication_protocols/mcp/README.md
+++ b/plugins/communication_protocols/mcp/README.md
@@ -187,6 +187,16 @@ except TimeoutError:
     print("MCP server connection timed out")
 ```
 
+### Child Process stderr
+
+Stdio MCP servers often write banners, telemetry notices and auth chatter to stderr, multiplied by every server you federate. `utcp-mcp` therefore discards the child's stderr by default. To see it while debugging a server that fails to start, opt back in for the host process:
+
+```bash
+UTCP_MCP_CHILD_STDERR=inherit python your_app.py
+```
+
+Any other value, or leaving the variable unset, keeps stderr suppressed. When a stdio server fails to connect, the error log reminds you of this switch.
+
 ### List Available Tools
 ```python
 # Discover tools from MCP server

--- a/plugins/communication_protocols/mcp/pyproject.toml
+++ b/plugins/communication_protocols/mcp/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "pydantic>=2.0",
-    "mcp>=1.12",
+    "mcp>=1.12,<2",
     "utcp>=1.1",
     "mcp-use>=1.3",
     "langchain>=0.3.27,<0.4.0",

--- a/plugins/communication_protocols/mcp/src/utcp_mcp/mcp_communication_protocol.py
+++ b/plugins/communication_protocols/mcp/src/utcp_mcp/mcp_communication_protocol.py
@@ -1,5 +1,6 @@
+import os
 import sys
-from typing import Any, Dict, Optional, AsyncGenerator, TYPE_CHECKING, Tuple
+from typing import Any, Dict, Optional, AsyncGenerator, TYPE_CHECKING, Tuple, TextIO
 import json
 
 from mcp_use import MCPClient
@@ -22,6 +23,56 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+
+# Environment variable that opts stdio MCP children back into writing to the
+# host's stderr. Same name and semantics as the TypeScript SDK.
+CHILD_STDERR_ENV_VAR = "UTCP_MCP_CHILD_STDERR"
+
+_devnull: Optional[TextIO] = None
+
+
+def _child_stderr_target() -> TextIO:
+    """Return the stream stdio MCP children should write their stderr to.
+
+    Defaults to ``os.devnull`` so a chatty server (banners, telemetry notices,
+    auth chatter, multiplied by every federated server) does not flood the host
+    terminal during discovery. Set ``UTCP_MCP_CHILD_STDERR=inherit`` to see it
+    while debugging. A file object rather than ``subprocess.DEVNULL`` because
+    the connector's contract is a text stream.
+    """
+    if os.environ.get(CHILD_STDERR_ENV_VAR) == "inherit":
+        return sys.stderr
+    global _devnull
+    if _devnull is None or _devnull.closed:
+        _devnull = open(os.devnull, "w")
+    return _devnull
+
+
+class _QuietStdioMCPClient(MCPClient):
+    """``MCPClient`` that routes stdio children's stderr per ``UTCP_MCP_CHILD_STDERR``.
+
+    ``MCPClient.from_dict`` offers no way to set the ``errlog`` that
+    ``StdioConnector`` hands to the MCP SDK's ``stdio_client``, so every child
+    would inherit the host's stderr. The connector only reads ``errlog`` when it
+    connects, so it is enough to set it between construction and initialization.
+    """
+
+    async def create_session(self, server_name: str, auto_initialize: bool = True):
+        session = await super().create_session(server_name, auto_initialize=False)
+        if session is None:
+            return None
+        if hasattr(session.connector, "errlog"):
+            session.connector.errlog = _child_stderr_target()
+        if auto_initialize:
+            try:
+                await session.initialize()
+            except Exception:
+                # Mirror the base class: a session that failed to initialize must
+                # not stay cached, or the next lookup would hand back a dead one.
+                self.sessions.pop(server_name, None)
+                raise
+        return session
+
 
 class McpCommunicationProtocol(CommunicationProtocol):
     """REQUIRED
@@ -52,7 +103,7 @@ class McpCommunicationProtocol(CommunicationProtocol):
         if self._mcp_client is None or self._mcp_client.config != manual_call_template.config.mcpServers:
             # Create a new MCPClient with the server configuration
             config = {"mcpServers": manual_call_template.config.mcpServers}
-            self._mcp_client = MCPClient.from_dict(config)
+            self._mcp_client = _QuietStdioMCPClient.from_dict(config)
 
     async def _get_or_create_session(self, server_name: str, manual_call_template: 'McpCallTemplate'):
         """Get an existing session or create a new one using MCPClient."""
@@ -66,7 +117,17 @@ class McpCommunicationProtocol(CommunicationProtocol):
         except ValueError:
             # Session doesn't exist, create a new one
             self._log_info(f"Creating new session for server: {server_name}")
-            session = await self._mcp_client.create_session(server_name, auto_initialize=True)
+            try:
+                session = await self._mcp_client.create_session(server_name, auto_initialize=True)
+            except Exception as e:
+                server_config = manual_call_template.config.mcpServers.get(server_name)
+                is_stdio = isinstance(server_config, dict) and "command" in server_config
+                if is_stdio and os.environ.get(CHILD_STDERR_ENV_VAR) != "inherit":
+                    self._log_error(
+                        f"Failed to start stdio MCP server '{server_name}': {e}. The child's stderr was "
+                        f"suppressed; re-run with {CHILD_STDERR_ENV_VAR}=inherit to see what it printed while starting."
+                    )
+                raise
             return session
 
     async def _cleanup_session(self, server_name: str):
@@ -384,13 +445,16 @@ class McpCommunicationProtocol(CommunicationProtocol):
     def _process_tool_result(self, result, tool_name: str) -> Any:
         self._log_info(f"Processing tool result for '{tool_name}', type: {type(result)}")
         
-        # Check for structured output first - this is the expected behavior
-        if hasattr(result, 'structuredContent'):
-            self._log_info(f"Found structuredContent: {result.structuredContent}")
-            # If structuredContent has a 'result' key, unwrap it
-            if isinstance(result.structuredContent, dict) and 'result' in result.structuredContent:
-                return result.structuredContent['result']
-            return result.structuredContent
+        # Prefer structuredContent (MCP spec field) whenever the server sent it.
+        structured = getattr(result, 'structuredContent', None)
+        if structured is not None:
+            self._log_info(f"Found structuredContent: {structured}")
+            # FastMCP wraps non-object returns as {"result": value}; unwrap exactly
+            # that single-key shape. An object that merely has a "result" key among
+            # others is a genuine object return and passes through untouched.
+            if isinstance(structured, dict) and set(structured.keys()) == {"result"}:
+                return structured["result"]
+            return structured
         
         # Process content if available (fallback)
         if hasattr(result, 'content'):

--- a/plugins/communication_protocols/mcp/src/utcp_mcp/mcp_communication_protocol.py
+++ b/plugins/communication_protocols/mcp/src/utcp_mcp/mcp_communication_protocol.py
@@ -449,10 +449,19 @@ class McpCommunicationProtocol(CommunicationProtocol):
         structured = getattr(result, 'structuredContent', None)
         if structured is not None:
             self._log_info(f"Found structuredContent: {structured}")
-            # FastMCP wraps non-object returns as {"result": value}; unwrap exactly
-            # that single-key shape. An object that merely has a "result" key among
-            # others is a genuine object return and passes through untouched.
-            if isinstance(structured, dict) and set(structured.keys()) == {"result"}:
+            # FastMCP wraps NON-OBJECT returns (primitives, lists, None) as
+            # {"result": value}; object returns are sent as-is. Unwrap exactly that
+            # shape: a single "result" key whose value is not a dict. A single-key
+            # {"result": {...}} is therefore a genuine object return and passes
+            # through untouched, as does any dict with other keys. A genuine
+            # {"result": <primitive or list>} return is indistinguishable from the
+            # wrapper on the wire and is unwrapped too; that ambiguity is inherent
+            # to the FastMCP convention.
+            if (
+                isinstance(structured, dict)
+                and set(structured.keys()) == {"result"}
+                and not isinstance(structured["result"], dict)
+            ):
                 return structured["result"]
             return structured
         

--- a/plugins/communication_protocols/mcp/tests/test_mcp_transport.py
+++ b/plugins/communication_protocols/mcp/tests/test_mcp_transport.py
@@ -280,6 +280,12 @@ async def test_process_tool_result_unwraps_only_single_key_result_wrapper(transp
         SimpleNamespace(structuredContent={"result": 1, "extra": 2}, content=[]), "t"
     ) == {"result": 1, "extra": 2}
     assert transport._process_tool_result(SimpleNamespace(structuredContent={"answer": 42}, content=[]), "t") == {"answer": 42}
+    assert transport._process_tool_result(SimpleNamespace(structuredContent={"result": ["a", "b"]}, content=[]), "t") == ["a", "b"]
+    # FastMCP only wraps non-object returns, so {"result": {...}} is a genuine
+    # object return from the tool and must keep its shape.
+    assert transport._process_tool_result(
+        SimpleNamespace(structuredContent={"result": {"nested": True}}, content=[]), "t"
+    ) == {"result": {"nested": True}}
     # No structuredContent: fall back to text content.
     text_only = SimpleNamespace(structuredContent=None, content=[SimpleNamespace(text="7")])
     assert transport._process_tool_result(text_only, "t") == 7

--- a/plugins/communication_protocols/mcp/tests/test_mcp_transport.py
+++ b/plugins/communication_protocols/mcp/tests/test_mcp_transport.py
@@ -244,3 +244,42 @@ async def test_resource_tool_without_registration(transport: McpCommunicationPro
     # Should still work and return content
     assert isinstance(result, dict)
     assert "contents" in result
+
+
+# --- Child stderr routing and structuredContent unwrapping ---
+
+@pytest.mark.asyncio
+async def test_stdio_child_stderr_suppressed_by_default(transport: McpCommunicationProtocol, mcp_manual: McpCallTemplate, monkeypatch):
+    """Without the opt-in, stdio children write stderr to os.devnull, not the host's stderr."""
+    monkeypatch.delenv("UTCP_MCP_CHILD_STDERR", raising=False)
+    session = await transport._get_or_create_session(SERVER_NAME, mcp_manual)
+    try:
+        assert session.connector.errlog is not sys.stderr
+        assert session.connector.errlog.name == os.devnull
+    finally:
+        await transport._cleanup_session(SERVER_NAME)
+
+
+@pytest.mark.asyncio
+async def test_stdio_child_stderr_inherit_opt_in(transport: McpCommunicationProtocol, mcp_manual: McpCallTemplate, monkeypatch):
+    """UTCP_MCP_CHILD_STDERR=inherit restores the host's stderr for debugging."""
+    monkeypatch.setenv("UTCP_MCP_CHILD_STDERR", "inherit")
+    session = await transport._get_or_create_session(SERVER_NAME, mcp_manual)
+    try:
+        assert session.connector.errlog is sys.stderr
+    finally:
+        await transport._cleanup_session(SERVER_NAME)
+
+
+@pytest.mark.asyncio
+async def test_process_tool_result_unwraps_only_single_key_result_wrapper(transport: McpCommunicationProtocol):
+    """A FastMCP {"result": x} wrapper is unwrapped; a real object with a result key is not."""
+    from types import SimpleNamespace
+    assert transport._process_tool_result(SimpleNamespace(structuredContent={"result": 42}, content=[]), "t") == 42
+    assert transport._process_tool_result(
+        SimpleNamespace(structuredContent={"result": 1, "extra": 2}, content=[]), "t"
+    ) == {"result": 1, "extra": 2}
+    assert transport._process_tool_result(SimpleNamespace(structuredContent={"answer": 42}, content=[]), "t") == {"answer": 42}
+    # No structuredContent: fall back to text content.
+    text_only = SimpleNamespace(structuredContent=None, content=[SimpleNamespace(text="7")])
+    assert transport._process_tool_result(text_only, "t") == 7


### PR DESCRIPTION
## Summary

Python counterpart of universal-tool-calling-protocol/typescript-utcp#42 (which lands typescript-utcp#33 plus follow-ups), so both SDKs ship the same MCP behavior in the next release.

Also carries the `mcp<2` pin commit from #100 so CI can collect the MCP tests; if #100 merges first this hunk merges cleanly as an identical change.

**Stdio child stderr is discarded by default.** Stdio MCP servers write banners, telemetry notices and auth chatter to stderr, multiplied by every federated server. mcp-use's `MCPClient.from_dict` gives no way to set the `errlog` that `StdioConnector` hands to the SDK's `stdio_client`, so a thin `MCPClient` subclass sets the connector's `errlog` to `os.devnull` between construction and initialization (the connector only reads it on connect). `UTCP_MCP_CHILD_STDERR=inherit` restores the host's stderr for debugging, the same switch as the TypeScript SDK, and a stdio server that fails to start logs a hint pointing at it.

**structuredContent handling tightened.** The previous `hasattr(result, 'structuredContent')` check is always true on `CallToolResult`, so it is now `is not None`. FastMCP wraps non-object returns as `{"result": value}`; that single-key wrapper is still unwrapped, but an object that merely has a `result` key among others now passes through untouched instead of losing its sibling keys. TypeScript gets the same rule in the companion PR.

**Not ported:** the circular `$ref` fix from #33. This plugin passes MCP schemas through without dereferencing them, so it cannot hit that bug.

## Test plan
- [x] New tests: default `errlog` is `os.devnull`; `UTCP_MCP_CHILD_STDERR=inherit` yields `sys.stderr`; single-key unwrap rule and text fallback
- [x] `pytest plugins/communication_protocols/mcp/tests`: 23 passed, three consecutive runs
- [x] README section on child process stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stdio MCP children now suppress stderr by default instead of inheriting the host's stderr, and `structuredContent` handling preserves object-shaped tool results. This aligns the Python plugin with the TypeScript SDK while adding a debug path for failed stdio servers.

**Behavior changes**
- Set `UTCP_MCP_CHILD_STDERR=inherit` to restore child stderr; startup errors mention this switch when stderr is suppressed.
- Only unwrap single-key `{"result": value}` wrappers when `value` is not a dict; objects with sibling keys or a nested object keep their full shape.
- `structuredContent=None` falls back to text content as before.

**Dependencies**
- Pin `mcp` to `<2` because version 2 removed APIs used by the plugin's test mocks.
- The circular `$ref` fix is not included because this plugin passes MCP schemas through without dereferencing them.

<sup>Written for commit b824c075b7efb8bc32ddd355c99cf8dd1bc30293. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/python-utcp/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

